### PR TITLE
Update Dockerfile for nth vice ciphey

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -2,17 +2,16 @@ FROM python:3.9-slim
 
 USER root
 
-RUN pip3 install --upgrade pip && \
-		pip3 install --upgrade name-that-hash && \
-		groupadd -r nonroot && \
-		useradd -m -r -g nonroot -d /home/nonroot -s /usr/sbin/nologin -c "Nonroot User" nonroot && \
-		mkdir -p /home/nonroot/workdir && \
-		chown -R nonroot:nonroot /home/nonroot
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade name-that-hash && \
+    groupadd -r nonroot && \
+    useradd -m -r -g nonroot -d /home/nonroot -s /usr/sbin/nologin -c "Nonroot User" nonroot && \
+    mkdir -p /home/nonroot/workdir && \
+    chown -R nonroot:nonroot /home/nonroot
 
 USER nonroot
 ENV HOME /home/nonroot
 WORKDIR /home/nonroot/workdir
 VOLUME ["/home/nonroot/workdir"]
 ENV USER nonroot
-ENTRYPOINT ["/usr/local/bin/ciphey"]
-CMD ["--help"]
+ENTRYPOINT ["/usr/local/bin/nth"]


### PR DESCRIPTION
Previous dockerfile entrypoint was pointed at 'ciphey' vice 'nth'. Corrected this, and removed the 'CMD' at the bottom.
Tested with `sudo docker run --rm -it nth:latest --text '5f4dcc3b5aa765d61d8327deb882cf99'` and with `--greppable` and had success with both commands. 