### PR TITLE
Adding script interface for Name-That-Hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: clean virtualenv test docker dist dist-upload
+
+clean:
+	find . -name '*.py[co]' -delete
+
+virtualenv:
+	virtualenv --prompt '(nth)' env
+	env/bin/pip3 install -r requirements-dev.txt
+	env/bin/python3 setup.py develop
+	@echo
+	@echo "VirtualENV Setup Complete. Now run: source env/bin/activate"
+	@echo
+
+pkg:
+	python3 -m pip install -r requirements.txt
+
+pkgdev:
+	python3 -m pip install -r requirements-dev.txt
+
+install:
+	python3 -m pip install -r requirements.txt
+	python3 -m pip install .
+	
+installdev:
+	python3 -m pip install -r requirements-dev.txt
+	python3 -m pip install . --verbose
+
+dist: clean
+	rm -rf dist/*
+	python setup.py sdist
+	python setup.py bdist_wheel
+
+dist-upload:
+	twine upload dist/* --verbose

--- a/name_that_hash/__init__.py
+++ b/name_that_hash/__init__.py
@@ -1,6 +1,13 @@
 __version__ = "0.1.0"
 
+# cli interface
 from name_that_hash import runner
+
+# script interface
+from name_that_hash.runner import (
+    identify_hash,
+    identify_hashes
+)
 
 if __name__ == "__main__":
     runner.main()

--- a/name_that_hash/check_hashes.py
+++ b/name_that_hash/check_hashes.py
@@ -24,7 +24,8 @@ class HashChecker:
             self.single_hash(line)
 
     def single_hash(self, chash: str):
-        if "base64" in self.kwargs:
+        # "base64" in self.kwargs is always True no matter if self.kwargs["base64"] is True or False
+        if self.kwargs["base64"]:
 
             logger.trace("decoding as base64")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest
+pytest==5.*,>=5.2.0
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click
+loguru
+rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click
-loguru
-rich
+click==7.*,>=7.1.2
+loguru==0.*,>=0.5.3
+rich==9.*,>=9.9.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             "name-that-hash = name_that_hash.runner:main",
         ]
     },
-    packages=["Name_That_Hash"],
+    packages=["name_that_hash"],
     package_dir={"": "."},
     package_data={},
     install_requires=["click==7.*,>=7.1.2", "loguru==0.*,>=0.5.3", "rich==9.*,>=9.9.0"],


### PR DESCRIPTION
Hello, 
I think that **Name-That-Hash** will have a script interface to interact with it writing python scripts ( and  use **nth** in other packages), so I have added two functions **identify_hash** and **identify_hashes** inside runner.py script that perform the same work that **nth** command line and return a dictionary with the following format:  `{QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...], ...} `
Also I have added a Makefile to automatize some developer activities (instalation of **name_that_hash** package, creation of a python virtual enviroment and publication in pypi).

I really appreciate if you can upload **Name-That-Hash** to pypi with the incorporated changes, so I can use **name_that_hash** package as plugin for [ama](https://github.com/fpolit/ama-framework)


glozanoa