### PR TITLE
adding api_return_hashes_identity function to nth API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: clean virtualenv test docker dist dist-upload
+
+clean:
+	find . -name '*.py[co]' -delete
+
+virtualenv:
+	virtualenv --prompt '(nth)' env
+	env/bin/pip3 install -r requirements-dev.txt
+	env/bin/python3 setup.py develop
+	@echo
+	@echo "VirtualENV Setup Complete. Now run: source env/bin/activate"
+	@echo
+
+pkg:
+	python3 -m pip install -r requirements.txt
+
+pkgdev:
+	python3 -m pip install -r requirements-dev.txt
+
+install:
+	python3 -m pip install -r requirements.txt
+	python3 -m pip install .
+	
+installdev:
+	python3 -m pip install -r requirements-dev.txt
+	python3 -m pip install . --verbose
+
+dist: clean
+	rm -rf dist/*
+	python setup.py sdist
+	python setup.py bdist_wheel
+
+dist-upload:
+	twine upload dist/* --verbose

--- a/name_that_hash/__init__.py
+++ b/name_that_hash/__init__.py
@@ -1,6 +1,13 @@
 __version__ = "0.1.0"
 
+# cli interface
 from name_that_hash import runner
+
+# script interface
+from name_that_hash.runner import (
+    identify_hash,
+    identify_hashes
+)
 
 if __name__ == "__main__":
     runner.main()

--- a/name_that_hash/__init__.py
+++ b/name_that_hash/__init__.py
@@ -5,8 +5,8 @@ from name_that_hash import runner
 
 # script interface
 from name_that_hash.runner import (
-    identify_hash,
-    identify_hashes
+    api_return_hashes_as_json,
+    api_return_hashes_identity
 )
 
 if __name__ == "__main__":

--- a/name_that_hash/check_hashes.py
+++ b/name_that_hash/check_hashes.py
@@ -24,7 +24,8 @@ class HashChecker:
             self.single_hash(line)
 
     def single_hash(self, chash: str):
-        if "base64" in self.kwargs:
+        # "base64" in self.kwargs is always True no matter if self.kwargs["base64"] is True or False
+        if self.kwargs["base64"]:
 
             logger.trace("decoding as base64")
 

--- a/name_that_hash/prettifier.py
+++ b/name_that_hash/prettifier.py
@@ -30,12 +30,13 @@ class Prettifier:
 
         Doesn't print it, it prints in main
         """
+        #import pdb; pdb.set_trace()
         outputs_as_dict = {}
         for i in objs:
             logger.debug(f"In for loop with object {i}")
-            for y in i:
-                outputs_as_dict.update(y.hash_obj)
-                logger.debug(f"Output_as_dicts is now {outputs_as_dict}")
+            #for y in i:
+            outputs_as_dict.update(i.hash_obj)
+            logger.debug(f"Output_as_dicts is now {outputs_as_dict}")
         return json.dumps(outputs_as_dict, indent=2)
 
     def pretty_print(self, objs):

--- a/name_that_hash/runner.py
+++ b/name_that_hash/runner.py
@@ -129,167 +129,6 @@ def main(**kwargs):
         pretty_printer.pretty_print(output)
 
 
-def identify_hash(*, query_hash:str,
-                    greppable:bool = False, base64:bool = False,
-                    accessible:bool = False, show_banner:bool = True,
-                    john:bool = True, hashcat:bool = True,
-                    quiet:bool = False, verbose:bool = False):
-    """Name That Hash - Instantly name the type of any hash!
-
-    NTH script interface
-
-    Github:\n
-    https://github.com/hashpals/name-that-hash
-
-    From the creator of RustScan and Ciphey. Follow me on Twitter!\n
-    https://twitter.com/bee_sec_san
-
-    Example usage:\n
-        from name_that_hash import identify_hash
-
-        ## identify a simple hash (similar to nth command line)
-        ## x : {QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...]}
-        x = identify_hashes(query_hash="5f4dcc3b5aa765d61d8327deb882cf99")
-
-        ## base64, greppable, accessible, verbose work similar to nth command line
-        ## quiet option doesn't show any output to command line and
-                simply return {QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...]}
-        ## show_banner options show the banner if is True otherwise doesn't show it
-        ## john and hashcat show the hash type of jtr or hc if are True otherwise don't show them
-    """
-    #import pdb; pdb.set_trace()
-
-    # Load the verbosity, so that we can start logging
-    set_logger({'verbose': verbose})
-
-    kwargs = {
-        "base64": base64,
-        'greppable': greppable,
-        'accessible': accessible,
-        'no_banner': not show_banner,
-        'no_john': not john,
-        'no_hashcat': not hashcat,
-        'verbose': verbose
-    }
-
-    logger.debug(kwargs)
-
-    # Banner handling
-    if show_banner and not (accessible or greppable or quiet):
-        logger.info("Running the banner.")
-        banner()
-
-    # nth = the object which names the hash types
-    nth = hash_namer.Name_That_Hash(hashes.prototypes)
-    # prettifier print things :)
-    pretty_printer = prettifier.Prettifier(kwargs)
-
-    hashChecker = check_hashes.HashChecker(kwargs, nth)
-
-    logger.trace("Initialized the hash_info, nth, and pretty_printer objects.")
-
-    output = []
-
-    hashChecker.single_hash(query_hash)
-    output = hashChecker.output
-
-    if not quiet:
-        if greppable:
-            print(pretty_printer.greppable_output([output]))
-        else:
-            pretty_printer.pretty_print(output)
-
-
-    hashType = output[0]
-    posible_hash_identities = hashType.hash_obj
-
-    return posible_hash_identities #{QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...]}
-
-
-def identify_hashes(*, hashes_file:str,
-                    greppable:bool = False, base64:bool = False,
-                    accessible:bool = False, show_banner:bool = True,
-                    john:bool = True, hashcat:bool = True,
-                    quiet:bool = False,verbose:bool = False):
-    """Name That Hash - Instantly name the type of any hash!
-
-    Github:\n
-    https://github.com/hashpals/name-that-hash
-
-    From the creator of RustScan and Ciphey. Follow me on Twitter!\n
-    https://twitter.com/bee_sec_san
-
-    Example usage:\n
-        from name_that_hash import identify_hash
-
-        ## identify a simple hash (similar to nth command line)
-        ## x : {QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...], ...}
-        x = identify_hashes(hashes_file=PATH_TO_HASHES_FILE)
-
-        ## base64, greppable, accessible, verbose work similar to nth command line
-        ## quiet option doesn't show any output to command line and
-                simply return {QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...], ...}
-        ## show_banner options show the banner if is True otherwise doesn't show it
-        ## john and hashcat show the hash type of jtr or hc if are True otherwise don't show them
-    """
-    #import pdb; pdb.set_trace()
-
-    try:
-        if not (os.path.isfile(hashes_file) and os.access(hashes_file, os.R_OK)):
-            if not os.path.isfile(hashes_file):
-                raise FileNotFoundError(f"Hashes file {hashes_file} doesn't exist")
-            else: # hashes file hasn't read permission
-                raise PermissionError(f"Hashes file has not read permission")
-
-        # Load the verbosity, so that we can start logging
-        set_logger({'verbose': verbose})
-
-        kwargs = {
-            "base64": base64,
-            'greppable': greppable,
-            'accessible': accessible,
-            'no_banner': not show_banner,
-            'no_john': not john,
-            'no_hashcat': not hashcat,
-            'verbose': verbose
-        }
-
-        logger.debug(kwargs)
-
-        # Banner handling
-        if show_banner and not (accessible or greppable or quiet):
-            logger.info("Running the banner.")
-            banner()
-
-        # nth = the object which names the hash types
-        nth = hash_namer.Name_That_Hash(hashes.prototypes)
-        # prettifier print things :)
-        pretty_printer = prettifier.Prettifier(kwargs)
-
-        hashChecker = check_hashes.HashChecker(kwargs, nth)
-
-        logger.trace("Initialized the hash_info, nth, and pretty_printer objects.")
-
-        output = []
-
-        with open(hashes_file, 'r') as query_hashes:
-            hashChecker.file_input(query_hashes)
-        output = hashChecker.output
-
-        if not quiet:
-            if greppable:
-                print(pretty_printer.greppable_output([output]))
-            else:
-                pretty_printer.pretty_print(output)
-
-
-        posible_hashes_identities = [hashType.hash_obj for hashType in output]
-
-        return posible_hashes_identities #{QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...], ...}
-
-    except Exception as error:
-        print(error)
-
 def set_logger(kwargs):
     try:
         logger_dict = {1: "WARNING", 2: "DEBUG", 3: "TRACE"}
@@ -319,6 +158,29 @@ def api_return_hashes_as_json(chash: [str], args: dict = {}):
         hashChecker.single_hash(i)
         output.append(hashChecker.output)
     return pretty_printer.greppable_output(output)
+
+
+def api_return_hashes_identity(chash: [str], args: dict = {}):
+    """
+    Using name-that-hash as an API? Call this function!
+
+    Given a list of hashes of strings
+    return a list of dictionaries with the supplied hashes as key and the posible identities as values
+    return format: [{QUERY_HASH : [{POSIBLE_HASH_IDENTITY}, ...]}, ...]
+    """
+    # nth = the object which names the hash types
+
+    import pdb; pdb.set_trace()
+    nth = hash_namer.Name_That_Hash(hashes.prototypes)
+    hashChecker = check_hashes.HashChecker(args, nth)
+
+    output = []
+
+    for i in chash:
+        hashChecker.single_hash(i)
+        output.append(hashChecker.output)
+
+    return [hashTypeObj[0].hash_obj for hashTypeObj in output]
 
 
 if __name__ == "__main__":

--- a/name_that_hash/runner.py
+++ b/name_that_hash/runner.py
@@ -148,16 +148,16 @@ def api_return_hashes_as_json(chash: [str], args: dict = {}):
     """
     # nth = the object which names the hash types
 
+    import pdb; pdb.set_trace()
+
     nth = hash_namer.Name_That_Hash(hashes.prototypes)
     # prettifier print things :)
     pretty_printer = prettifier.Prettifier(args, api=True)
     hashChecker = check_hashes.HashChecker(args, nth)
 
-    output = []
     for i in chash:
         hashChecker.single_hash(i)
-        output.append(hashChecker.output)
-    return pretty_printer.greppable_output(output)
+    return pretty_printer.greppable_output(hashChecker.output)
 
 
 def api_return_hashes_identity(chash: [str], args: dict = {}):
@@ -170,17 +170,14 @@ def api_return_hashes_identity(chash: [str], args: dict = {}):
     """
     # nth = the object which names the hash types
 
-    #import pdb; pdb.set_trace()
+    import pdb; pdb.set_trace()
     nth = hash_namer.Name_That_Hash(hashes.prototypes)
     hashChecker = check_hashes.HashChecker(args, nth)
 
-    output = []
-
     for i in chash:
         hashChecker.single_hash(i)
-        output.append(hashChecker.output)
 
-    return [hashTypeObj[0].hash_obj for hashTypeObj in output]
+    return [hashTypeObj.hash_obj for hashTypeObj in hashChecker.output]
 
 
 if __name__ == "__main__":

--- a/name_that_hash/runner.py
+++ b/name_that_hash/runner.py
@@ -170,7 +170,7 @@ def api_return_hashes_identity(chash: [str], args: dict = {}):
     """
     # nth = the object which names the hash types
 
-    import pdb; pdb.set_trace()
+    #import pdb; pdb.set_trace()
     nth = hash_namer.Name_That_Hash(hashes.prototypes)
     hashChecker = check_hashes.HashChecker(args, nth)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest
+pytest==5.*,>=5.2.0
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click
+loguru
+rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click
-loguru
-rich
+click==7.*,>=7.1.2
+loguru==0.*,>=0.5.3
+rich==9.*,>=9.9.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             "name-that-hash = name_that_hash.runner:main",
         ]
     },
-    packages=["Name_That_Hash"],
+    packages=["name_that_hash"],
     package_dir={"": "."},
     package_data={},
     install_requires=["click==7.*,>=7.1.2", "loguru==0.*,>=0.5.3", "rich==9.*,>=9.9.0"],


### PR DESCRIPTION
Hello,
I think that the function `api_return_hashes_as_json(chash: [str], args: dict = {})` of the `runner.py` module is great, but it return formatted JSON output text  ,I think that a function that return a python dictionary will be useful to avoid the process of loading the formatted JSON text to python with `json` library. I have written a similar function (`api_return_hashes_identity(chash: [str], args: dict = {})`) that made it.

You can test it as follow:

cd NAME_THAT_HASH_REPO
make installdev

Open ipython
from name_that_hash import api_return_hashes_identity

x = api_return_hashes_identity(["5f4dcc3b5aa765d61d8327deb882cf99"])