### PR TITLE
Added a space before "Summary" in the output if there is no john 

### DIFF
--- a/name_that_hash/prettifier.py
+++ b/name_that_hash/prettifier.py
@@ -62,7 +62,7 @@ class Prettifier:
     def pretty_print_one(self, objs: List, multi_print: bool):
         out = f"\n[bold magenta]{objs.chash}[/bold magenta]\n"
 
-        # It didn't find any hahses.
+        # It didn't find any hashes.
         if len(objs.prototypes) == 0:
             out += "[bold #FF0000]No hashes found.[/bold #FF0000]"
             console.print(out)

--- a/name_that_hash/prettifier.py
+++ b/name_that_hash/prettifier.py
@@ -102,7 +102,7 @@ class Prettifier:
             if hc is not None and john:
                 out += f"HC: {hc} "
             elif hc is not None:
-                out += f"HC: {hc}"
+                out += f"HC: {hc} "
 
         if not self.john:
             if john is not None and des:


### PR DESCRIPTION
I noticed that if there is only hashcat printed without john, there is no space before summary. If I understand the code correctly, this should add a space after HC if there is no john.

![screenshot](https://user-images.githubusercontent.com/63184600/111831561-d9f1dd00-88ef-11eb-888f-98903d7a43e0.png)

While reading the code I also noticed a small typo in the comment, so that is also fixed. :)