### PR TITLE
More Kerberos hash types need to be separated into a salt and without a salt

### DIFF
--- a/name_that_hash/hashes.py
+++ b/name_that_hash/hashes.py
@@ -1630,12 +1630,24 @@ prototypes = [
         ],
     ),
     Prototype(
-        regex=re.compile(r"^\$krb5pa\$18\$[^$]{1,512}\$[^$]{1,512}\$\$?[^$]{1,512}?\$?[a-f0-9]{104,112}$", re.IGNORECASE),
+        regex=re.compile(r"^\$krb5pa\$18\$[^$]{1,512}\$[^$]{1,512}\$[^$]{0,512}\$[a-f0-9]{104,112}$", re.IGNORECASE),
+        modes=[
+            HashInfo(
+                name="Kerberos 5, etype 18, Pre-Auth (with salt)",
+                hashcat=None,
+                john="krb5pa-sha1",
+                extended=False,
+                description="Used for Windows Active Directory"
+                )
+        ],
+    ),
+    Prototype(
+        regex=re.compile(r"^\$krb5pa\$18\$[^$]{1,512}\$[^$]{1,512}\$[a-f0-9]{104,112}$", re.IGNORECASE),
         modes=[
             HashInfo(
                 name="Kerberos 5, etype 18, Pre-Auth",
                 hashcat=19900,
-                john="krb5pa-sha1",
+                john=None,
                 extended=False,
                 description="Used for Windows Active Directory"
                 )

--- a/name_that_hash/hashes.py
+++ b/name_that_hash/hashes.py
@@ -1618,7 +1618,7 @@ prototypes = [
         ],
     ),
     Prototype(
-        regex=re.compile(r"^\$krb5pa\$17\$[^$]{1,512}\$[^$]{1,512}\$\$[a-f0-9]{104,112}$", re.IGNORECASE),
+        regex=re.compile(r"^\$krb5pa\$17\$[^$]{1,512}\$[^$]{1,512}\$[^$]{0,512}\$[a-f0-9]{104,112}$", re.IGNORECASE),
         modes=[
             HashInfo(
                 name="Kerberos 5, etype 17, Pre-Auth (with salt)",


### PR DESCRIPTION
Thanks @bburky for this! I changed $krb5pa$17$ and $krb5pa$18$ as you suggested, so this two should work now with a salt and the change is included in this pull request. :)

I was also looking into separating $krb5tgs$18$ and $krb5tgs$17$ but I was unable to get john to detect either of them. I think john does not support this two hash types as the issue to add them on the john repo is still opened [#2809](https://github.com/openwall/john/issues/2809).

We separated other hash types into with a salt (for john) and without a salt (for hashcat), so what can we do with this two as hashcat doesn't support them with a salt and they are not supported in john either? We could also report this to hashcat, so they could start supporting all of them with a salt as @bburky suggested.