### PR TITLE
Added one new Office hash type and updated some of the old ones

### DIFF
--- a/name_that_hash/hashes.py
+++ b/name_that_hash/hashes.py
@@ -1358,7 +1358,7 @@ prototypes = [
         ),
         modes=[
             HashInfo(
-                name="Microsoft Office 2010", hashcat=9500, john=None, extended=False
+                name="Microsoft Office 2010", hashcat=9500, john="office", extended=False
             )
         ],
     ),
@@ -1369,7 +1369,7 @@ prototypes = [
         ),
         modes=[
             HashInfo(
-                name="Microsoft Office 2013", hashcat=9600, john=None, extended=False
+                name="Microsoft Office 2013", hashcat=9600, john="office", extended=False
             )
         ],
     ),
@@ -1417,12 +1417,6 @@ prototypes = [
                 john="oldoffice",
                 extended=False,
             ),
-            HashInfo(
-                name=u"Microsoft Office ≤ 2003 (MD5+RC4) collider-mode #2",
-                hashcat=9720,
-                john="oldoffice",
-                extended=False,
-            ),
         ],
     ),
     Prototype(
@@ -1434,21 +1428,26 @@ prototypes = [
             HashInfo(
                 name=u"Microsoft Office ≤ 2003 (SHA1+RC4)",
                 hashcat=9800,
-                john=None,
+                john="oldoffice",
                 extended=False,
             ),
             HashInfo(
                 name=u"Microsoft Office ≤ 2003 (SHA1+RC4) collider-mode #1",
                 hashcat=9810,
-                john=None,
+                john="oldoffice",
                 extended=False,
             ),
+        ],
+    ),
+    Prototype(
+        regex=re.compile(r"^\$oldoffice\$[34]\*[a-f0-9]{32}\*[a-f0-9]{32}\*[a-f0-9]{40}:[a-f0-9]{10}", re.IGNORECASE),
+        modes=[
             HashInfo(
-                name=u"Microsoft Office ≤ 2003 (SHA1+RC4) collider-mode #2",
+                name=u"MS Office ⇐ 2003 $3, SHA1 + RC4, collider #2",
                 hashcat=9820,
-                john=None,
+                john="oldoffice",
                 extended=False,
-            ),
+            )
         ],
     ),
     Prototype(
@@ -1791,9 +1790,20 @@ prototypes = [
             HashInfo(
                 name="MS Office ⇐ 2003 $0/$1, MD5 + RC4, collider #2",
                 hashcat=9720,
-                john=None,
+                john="oldoffice",
                 extended=False,
                 description="Use office2john.py to grab the hash."
+            ),
+        ],
+    ),
+    Prototype(
+        regex=re.compile(r"\$office\$2016\$[0-9]\$[0-9]{6}\$[^$]{24}\$[^$]{88}", re.IGNORECASE),
+        modes=[
+            HashInfo(
+                name="MS Office 2016 - SheetProtection",
+                hashcat=25300,
+                john=None,
+                extended=False,
             ),
         ],
     ),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -223,4 +223,20 @@ def test_office():
     ]
 
     x = runner.api_return_hashes_as_json(hashes)
-    assert re.findall("MS Office", x)
+    assert re.findall(r"MS Office [^#]+ MD5 \+ RC4[^#]+ #2", x)
+
+def test_office2():
+    hashes = [
+        "$oldoffice$3*83328705222323020515404251156288*2855956a165ff6511bc7f4cd77b9e101*941861655e73a09c40f7b1e9dfd0c256ed285acd:b8f63619ca"
+    ]
+
+    x = runner.api_return_hashes_as_json(hashes)
+    assert re.findall(r"MS Office [^#]+ SHA1 \+ RC4[^#]+ #2", x)
+
+def test_office3():
+    hashes = [
+        "$office$2016$0$100000$876MLoKTq42+/DLp415iZQ==$TNDvpvYyvlSUy97UOLKNhXynhUDDA7H8kLql0ISH5SxcP6hbthdjaTo4Z3/MU0dcR2SAd+AduYb3TB5CLZ8+ow=="
+    ]
+
+    x = runner.api_return_hashes_as_json(hashes)
+    assert "MS Office 2016 - SheetProtection" in x


### PR DESCRIPTION
I went through the Office hashes in the hashcat examples, added one new hash type and updated some of the old ones. Here are all of the changes:
- added `john="office"` to `Microsoft Office 2010` and to `Microsoft Office 2013`
- added `john="oldoffice"` to hash types 9800, 9810, 9820 and 9720 (I tested each example with john)
- separated `MS Office ⇐ 2003 $3, SHA1 + RC4, collider #2` as this hash type has another 10 characters at the end which caused it to not get matched to the hash
- same happened to the `MS Office ⇐ 2003 $0/$1, MD5 + RC4, collider #2` but it was added again, so it matched correctly but I removed the old entry
- added one new hash type `MS Office 2016 - SheetProtection`
- added two new tests - for the new one and for the one I separated

Pytest ran without any errors. Hope all the changes are okay as then we should be done with Office hash types :D