### PR TITLE
Added john mode to argon2i and argon2d

### DIFF
--- a/name_that_hash/hashes.py
+++ b/name_that_hash/hashes.py
@@ -2393,7 +2393,7 @@ prototypes = [
             HashInfo(
                 name="Argon2i",
                 hashcat=None,
-                john=None,
+                john="argon2",
                 extended=False,
             ),
         ],
@@ -2415,7 +2415,7 @@ prototypes = [
             HashInfo(
                 name="Argon2d",
                 hashcat=None,
-                john=None,
+                john="argon2",
                 extended=False,
             ),
         ],


### PR DESCRIPTION
I missed this previously, so this PR adds john mode to two of Argon types. Argon2id is not yet supported in john. 