### PR TITLE
Add regex and test for yescrypt

### DIFF
--- a/name_that_hash/hashes.py
+++ b/name_that_hash/hashes.py
@@ -748,6 +748,18 @@ prototypes = [
         ],
     ),
     Prototype(
+        regex=re.compile(r"^\$y\$[.\/A-Za-z0-9]+\$[.\/a-zA-Z0-9]+\$[.\/A-Za-z0-9]{43}$", re.IGNORECASE),
+        modes=[
+            HashInfo(
+                name="yescrypt",
+                hashcat="Not yet supported, see notes in summary.",
+                john="On systems that use libxcrypt, you may use --format=crypt to use JtR in passthrough mode which uses the system's crypt function.",
+                extended=False,
+                description="Can be used in Linux Shadow Files in modern Linux distributions like Ubuntu 22.04, Debian 11, Fedora 35. On hashcat this is not yet implemented, please vote (👍 \"thumbs up\") on this issue: https://github.com/hashcat/hashcat/issues/2816."
+            )
+        ],
+    ),
+    Prototype(
         regex=re.compile(r"^[a-f0-9]{40}:[a-f0-9]{16}$", re.IGNORECASE),
         modes=[HashInfo(name="Android PIN", hashcat=5800, john=None, extended=False)],
     ),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -372,3 +372,12 @@ def test_argon2d():
 
     x = runner.api_return_hashes_as_json(hashes)
     assert "Argon2d" in x
+
+
+def test_yescrypt():
+    hashes = [
+        "$y$j9T$.9s2wZRY3hcP/udKIFher1$sIBIYsiMmFlXhKOO4ZDJDXo54byuq7a4xAD0k9jw2m4"
+    ]
+
+    x = runner.api_return_hashes_as_json(hashes)
+    assert "yescrypt" in x


### PR DESCRIPTION
`yescrypt` is a hash algorithm being utilized in modern operating systems today like Ubuntu 2.204 (Jammy), Debian 11, and Fedora 35. This PR adds a simple regex to detect a yescrypt hash and output more helpful information.

To use the hash with JtR you need to use in on a system with libxcrypt and invoke it like so:
` john -wordlist=/path/to/wordlist -format=crypt hash`

yescrypt is not currently supported by Hashcat and I tried to make that clear in the output and in the summary as well. You can read more about that [here](https://github.com/hashcat/hashcat/issues/2816).

![image](https://user-images.githubusercontent.com/68455785/196814041-81c2ac36-4b6f-4cb4-b8af-6cdb5ff02dc7.png)
