### PR TITLE
Add JWT hash

### DIFF
--- a/name_that_hash/hashes.py
+++ b/name_that_hash/hashes.py
@@ -2632,5 +2632,16 @@ prototypes = [
                 extended=False
             ),
         ]
-    )
+    ),
+    Prototype(
+        regex=re.compile(r"^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$", re.IGNORECASE),
+        modes=[
+            HashInfo(
+                name="JWT (JSON Web Token)",
+                hashcat=16500,
+                john=None,
+                extended=False
+            ),
+        ]
+    ),
 ]

--- a/tests/test_hashcat.py
+++ b/tests/test_hashcat.py
@@ -1512,3 +1512,11 @@ def test_hashcat_13000():
 
     x = runner.api_return_hashes_as_json(hashes)
     assert '"hashcat": 13000,' in x
+
+def test_hashcat_16500():
+    hashes = [
+        "eyJhbGciOiJIUzI1NiJ9.eyIzNDM2MzQyMCI6NTc2ODc1NDd9.f1nXZ3V_Hrr6ee-AFCTLaHRnrkiKmio2t3JqwL32guY"
+    ]
+    
+    x = runner.api_return_hashes_as_json(hashes)
+    assert '"hashcat": 16500,' in x

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -480,3 +480,11 @@ def test_yescrypt():
 
     x = runner.api_return_hashes_as_json(hashes)
     assert "yescrypt" in x
+
+def test_jwt():
+    hashes = [
+        "eyJhbGciOiJIUzI1NiJ9.eyIzNDM2MzQyMCI6NTc2ODc1NDd9.f1nXZ3V_Hrr6ee-AFCTLaHRnrkiKmio2t3JqwL32guY"
+    ]
+
+    x = runner.api_return_hashes_as_json(hashes)
+    assert "JWT (JSON Web Token)" in x


### PR DESCRIPTION
A simple one, just a regex that matches three Base64 parts separated by periods. 

Hashcat can crack them with mode 16500 and john recognizes it automatically